### PR TITLE
Add relative qualifying time delta feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This repository contains utilities to download Formula 1 race data using the Jol
 - driver championship position after each race
 - team (constructor) championship points after each race
 - team championship position after each race
+- relative qualifying time delta in seconds
+- relative qualifying time delta as a percentage of pole time
 
 The script writes everything to `f1_data_2022_to_present.csv` in the current directory.
 


### PR DESCRIPTION
## Summary
- compute Relative Qualifying Time Delta using the qualifying endpoint
- record the delta in seconds and percent in the CSV
- mention the new columns in the README

## Testing
- `python -m py_compile data_collection.py`
- `python data_collection.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_684c5bea05088331a397d6598cfbf3a4