### PR TITLE
Improve dataset quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Raw responses are downloaded with `fetch_data.py` and stored under `jolpica_f1_c
 - circuit ID
 - start position on the grid
 - finish position
-- grid penalty places and flag
+- grid penalty places with separate penalty and bonus flags
 - Q2 qualifier flag
 - Q3 qualifier flag
 - total driver championship points after each race
@@ -18,6 +18,7 @@ Raw responses are downloaded with `fetch_data.py` and stored under `jolpica_f1_c
 - team championship position after each race
 - relative qualifying time delta in seconds
 - relative qualifying time delta as a percentage of pole time
+- drivers without a valid qualifying time are labelled as `no-time` for these deltas
 
 The script writes the prepared dataset to `f1_data_2022_to_present.csv` in the current directory.
 


### PR DESCRIPTION
## Summary
- parse numeric fields when writing CSV
- add `grid_bonus_flag` to differentiate grid penalties vs. grid gains
- mark missing qualifying deltas as `no-time`
- document new column and label handling in README

## Testing
- `python -m py_compile fetch_data.py process_data.py data_collection.py`
- `python process_data.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_684c99ae87048331a38a12453e919b4d