### PR TITLE
Handle numeric fields and grid bonuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Raw responses are downloaded with `fetch_data.py` and stored under `jolpica_f1_c
 - circuit ID
 - start position on the grid
 - finish position
-- grid penalty places and flag
+- grid penalty places with penalty and bonus flags
 - Q2 qualifier flag
 - Q3 qualifier flag
 - total driver championship points after each race


### PR DESCRIPTION
## Summary
- parse numeric fields when writing CSV
- add `grid_bonus_flag` column
- document bonus flag in README

## Testing
- `python -m py_compile fetch_data.py process_data.py data_collection.py`

------
https://chatgpt.com/codex/tasks/task_b_684c9d65aba48331870cc29fe624cf7b