### PR TITLE
Improve dataset processing for F1 model

### DIFF
--- a/process_data.py
+++ b/process_data.py
@@ -61,6 +61,15 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
     last = get_last_round(output_file)
     mode = "a" if last else "w"
 
+    # Keep track of last known driver standings position
+    last_driver_rank = {}
+
+    # Statistics for target/mean encoding of circuits and constructors
+    circuit_counts = {}
+    circuit_podiums = {}
+    constructor_counts = {}
+    constructor_podiums = {}
+
     with open(output_file, mode, newline="", encoding="utf-8") as csvfile:
         writer = csv.writer(csvfile)
         if not last:
@@ -83,6 +92,8 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                 "constructor_championship_rank",
                 "rqtd_sec",
                 "rqtd_pct",
+                "circuit_podium_rate",
+                "constructor_podium_rate",
             ])
 
         if last:
@@ -151,6 +162,30 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                     penalty_flag = 1 if penalty_places is not None and penalty_places > 0 else 0
                     bonus_flag = 1 if penalty_places is not None and penalty_places < 0 else 0
 
+                    # Handle missing championship rank
+                    rank = try_int(ds.get("position"))
+                    if rank is None:
+                        rank = last_driver_rank.get(driver, 999)
+                    else:
+                        last_driver_rank[driver] = rank
+
+                    # Sentinel values for missing qualifying times
+                    if best_times.get(driver) is not None and pole_time is not None:
+                        rqtd_sec = best_times[driver] - pole_time
+                        rqtd_pct = (best_times[driver] / pole_time - 1) * 100
+                    else:
+                        rqtd_sec = 5.0
+                        rqtd_pct = 5.0
+
+                    # Target/mean encoding features
+                    circ_count = circuit_counts.get(circuit_id, 0)
+                    circ_pods = circuit_podiums.get(circuit_id, 0)
+                    circuit_rate = circ_pods / circ_count if circ_count > 0 else 0.0
+
+                    cons_count = constructor_counts.get(constructor, 0)
+                    cons_pods = constructor_podiums.get(constructor, 0)
+                    constructor_rate = cons_pods / cons_count if cons_count > 0 else 0.0
+
                     writer.writerow([
                         season,
                         round_no,
@@ -164,13 +199,23 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                         qual_flags.get(driver, (0, 0))[0],
                         qual_flags.get(driver, (0, 0))[1],
                         try_float(ds.get("points")),
-                        try_int(ds.get("position")),
+                        rank,
                         constructor,
                         try_float(cs.get("points")),
                         try_int(cs.get("position")),
-                        best_times.get(driver) - pole_time if best_times.get(driver) is not None and pole_time is not None else None,
-                        (best_times.get(driver) / pole_time - 1) * 100 if best_times.get(driver) is not None and pole_time is not None else None,
+                        rqtd_sec,
+                        rqtd_pct,
+                        circuit_rate,
+                        constructor_rate,
                     ])
+
+                    # Update statistics after writing row
+                    if finish_pos is not None:
+                        circuit_counts[circuit_id] = circ_count + 1
+                        constructor_counts[constructor] = cons_count + 1
+                        if finish_pos <= 3:
+                            circuit_podiums[circuit_id] = circ_pods + 1
+                            constructor_podiums[constructor] = cons_pods + 1
 
                 log(f"✅ stored {len(results)} results for {season} round {round_no}")
                 round_no += 1


### PR DESCRIPTION
## Summary
- forward fill missing driver championship ranks
- add sentinel values for missing qualifying deltas
- generate target mean encoded circuit/constructor features

## Testing
- `python -m py_compile process_data.py fetch_data.py data_collection.py`
- `python process_data.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_684ca088cf748331b1c895330f36e9cd