### PR TITLE
Add new driver metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Raw responses are downloaded with `fetch_data.py` and stored under `jolpica_f1_c
 - team championship position after each race
 - relative qualifying time delta in seconds
 - relative qualifying time delta as a percentage of pole time
+- teammate qualifying gap in seconds
+- driver momentum over the last three races
+- pit stop difficulty index
 
 The script writes the prepared dataset to `f1_data_2022_to_present.csv` in the current directory.
 
@@ -57,5 +60,6 @@ All endpoints used by the script are documented in the `endpoints` directory. Th
 - `/{season}/{round}/results.json`
 - `/{season}/{round}/driverStandings.json`
 - `/{season}/{round}/constructorStandings.json`
+- `/{season}/{round}/pitstops/`
 
 Refer to the markdown files in the `endpoints` folder for details about optional query parameters and example responses.

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -116,7 +116,9 @@ def get_constructor_standings(season: int, round_no: int):
 
 def get_pitstops(season: int, round_no: int):
     """Return pit stop data for a given round."""
-    url = f"{BASE_URL}/{season}/{round_no}/pitstops.json"
+    # According to the Jolpica API docs the endpoint uses a trailing slash
+    # without the `.json` extension.
+    url = f"{BASE_URL}/{season}/{round_no}/pitstops/"
     data = fetch_json(url)
     races = data.get("RaceTable", {}).get("Races", [])
     if races:

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -114,13 +114,29 @@ def get_constructor_standings(season: int, round_no: int):
     return []
 
 
+def get_pitstops(season: int, round_no: int):
+    """Return pit stop data for a given round."""
+    url = f"{BASE_URL}/{season}/{round_no}/pitstops.json"
+    data = fetch_json(url)
+    races = data.get("RaceTable", {}).get("Races", [])
+    if races:
+        return races[0].get("PitStops", [])
+    return []
+
+
 def fetch_round_data(season: int, round_no: int):
     """Fetch and cache raw data for a given season and round."""
     os.makedirs(os.path.join(CACHE_DIR, str(season)), exist_ok=True)
     cache_file = os.path.join(CACHE_DIR, str(season), f"{round_no}.json")
     if os.path.exists(cache_file):
         with open(cache_file, encoding="utf-8") as f:
-            return json.load(f)
+            data = json.load(f)
+        # Add newly introduced fields if missing
+        if "pitstops" not in data:
+            data["pitstops"] = get_pitstops(season, round_no)
+            with open(cache_file, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+        return data
 
     circuit_id, results = get_results(season, round_no)
     if not results:
@@ -129,6 +145,7 @@ def fetch_round_data(season: int, round_no: int):
     driver_standings = get_driver_standings(season, round_no)
     cons_standings = get_constructor_standings(season, round_no)
     qual_results = get_qualifying_results(season, round_no)
+    pitstops = get_pitstops(season, round_no)
 
     data = {
         "circuit_id": circuit_id,
@@ -136,6 +153,7 @@ def fetch_round_data(season: int, round_no: int):
         "driver_standings": driver_standings,
         "constructor_standings": cons_standings,
         "qualifying": qual_results,
+        "pitstops": pitstops,
     }
 
     with open(cache_file, "w", encoding="utf-8") as f:

--- a/process_data.py
+++ b/process_data.py
@@ -83,6 +83,9 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                 "constructor_championship_rank",
                 "rqtd_sec",
                 "rqtd_pct",
+                "teammate_quali_gap_sec",
+                "driver_momentum",
+                "pit_stop_difficulty",
             ])
 
         if last:
@@ -90,6 +93,8 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
 
         start_s = last[0] if last else start_season
         start_r = last[1] + 1 if last else 1
+
+        points_history = {}
 
         for season in range(start_s, end_season + 1):
             round_no = start_r if season == start_s else 1
@@ -131,6 +136,22 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                     if vals:
                         pole_time = min(vals)
 
+                team_map = {}
+                for res in results:
+                    drv_id = res["Driver"]["driverId"]
+                    team_id = res["Constructor"]["constructorId"]
+                    team_map.setdefault(team_id, []).append(drv_id)
+
+                pit_durations = [
+                    try_float(p.get("duration"))
+                    for p in data.get("pitstops", [])
+                    if try_float(p.get("duration")) is not None
+                ]
+                pit_stop_difficulty = None
+                if pit_durations:
+                    avg_dur = sum(pit_durations) / len(pit_durations)
+                    pit_stop_difficulty = len(pit_durations) * avg_dur
+
                 # Convert standings to dicts for quick lookup
                 ds_map = {d["Driver"]["driverId"]: d for d in driver_standings}
                 cs_map = {c["Constructor"]["constructorId"]: c for c in cons_standings}
@@ -151,6 +172,27 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                     penalty_flag = 1 if penalty_places is not None and penalty_places > 0 else 0
                     bonus_flag = 1 if penalty_places is not None and penalty_places < 0 else 0
 
+                    teammates = [t for t in team_map.get(constructor, []) if t != driver]
+                    teammate_best = None
+                    if teammates:
+                        times = [best_times.get(t) for t in teammates if best_times.get(t) is not None]
+                        if times:
+                            teammate_best = min(times)
+                    teammate_gap = (
+                        best_times.get(driver) - teammate_best
+                        if best_times.get(driver) is not None and teammate_best is not None
+                        else None
+                    )
+
+                    points_total = try_float(ds.get("points"))
+                    history = points_history.setdefault(driver, [])
+                    history.append(points_total if points_total is not None else 0.0)
+                    momentum = None
+                    if len(history) >= 7:
+                        last3 = history[-1] - history[-4]
+                        prev3 = history[-4] - history[-7]
+                        momentum = last3 - prev3
+
                     writer.writerow([
                         season,
                         round_no,
@@ -170,6 +212,9 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                         try_int(cs.get("position")),
                         best_times.get(driver) - pole_time if best_times.get(driver) is not None and pole_time is not None else None,
                         (best_times.get(driver) / pole_time - 1) * 100 if best_times.get(driver) is not None and pole_time is not None else None,
+                        teammate_gap,
+                        momentum,
+                        pit_stop_difficulty,
                     ])
 
                 log(f"✅ stored {len(results)} results for {season} round {round_no}")


### PR DESCRIPTION
## Summary
- extend data fetching with pit stop info
- add teammate gap, driver momentum, and pit stop difficulty features

## Testing
- `python -m py_compile fetch_data.py process_data.py data_collection.py`

------
https://chatgpt.com/codex/tasks/task_b_684ca49b05308331a2664c8b4eac59a5