### PR TITLE
Handle missing F1 stats with sentinel values

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Raw responses are downloaded with `fetch_data.py` and stored under `jolpica_f1_c
 - team championship position after each race
 - relative qualifying time delta in seconds
 - relative qualifying time delta as a percentage of pole time
-- teammate qualifying gap in seconds
-- driver momentum over the last three races
+- teammate qualifying gap in seconds (uses 5.0 if no valid time for either driver)
+- driver momentum over the last three races (0.0 for the first six rounds)
 - pit stop difficulty index
 
 The script writes the prepared dataset to `f1_data_2022_to_present.csv` in the current directory.

--- a/process_data.py
+++ b/process_data.py
@@ -229,6 +229,8 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                         if best_times.get(driver) is not None and teammate_best is not None
                         else None
                     )
+                    if teammate_gap is None:
+                        teammate_gap = 5.0
 
                     points_total = try_float(ds.get("points"))
                     history = points_history.setdefault(driver, [])
@@ -238,6 +240,8 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                         last3 = history[-1] - history[-4]
                         prev3 = history[-4] - history[-7]
                         momentum = last3 - prev3
+                    else:
+                        momentum = 0.0
 
                     cons_points = try_float(cs.get("points"))
                     cons_hist = constructor_points_history.setdefault(constructor, [])


### PR DESCRIPTION
## Summary
- set a 5 second sentinel for missing teammate qualifying gaps
- use 0.0 as the initial driver momentum for the first six rounds
- document these sentinel values in the README

## Testing
- `python -m py_compile process_data.py`

------
https://chatgpt.com/codex/tasks/task_b_684cb104c9748331b03db9dd249ad731