### PR TITLE
Improve CSV fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Raw responses are downloaded with `fetch_data.py` and stored under `jolpica_f1_c
 - driver championship position after each race
 - team (constructor) championship points after each race
 - team championship position after each race
-- relative qualifying time delta in seconds
-- relative qualifying time delta as a percentage of pole time
+- relative qualifying time delta in seconds (uses 5.0 if no valid time)
+- relative qualifying time delta as a percentage of pole time (uses 5.0 if no valid time)
 - teammate qualifying gap in seconds (uses 5.0 if no valid time for either driver)
 - driver momentum over the last three races (0.0 for the first six rounds)
+- constructor momentum over the last three races (0.0 for the first six rounds)
 - pit stop difficulty index
 
 The script writes the prepared dataset to `f1_data_2022_to_present.csv` in the current directory.

--- a/process_data.py
+++ b/process_data.py
@@ -251,6 +251,21 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                         last3_c = cons_hist[-1] - cons_hist[-4]
                         prev3_c = cons_hist[-4] - cons_hist[-7]
                         cons_momentum = last3_c - prev3_c
+                    else:
+                        cons_momentum = 0.0
+
+                    gap_sec = (
+                        best_times.get(driver) - pole_time
+                        if best_times.get(driver) is not None and pole_time is not None
+                        else None
+                    )
+                    gap_pct = (
+                        (best_times.get(driver) / pole_time - 1) * 100
+                        if best_times.get(driver) is not None and pole_time is not None
+                        else None
+                    )
+                    gap_sec = gap_sec if gap_sec is not None else 5.0
+                    gap_pct = gap_pct if gap_pct is not None else 5.0
 
                     writer.writerow([
                         season,
@@ -269,8 +284,8 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                         constructor,
                         try_float(cs.get("points")),
                         try_int(cs.get("position")),
-                        best_times.get(driver) - pole_time if best_times.get(driver) is not None and pole_time is not None else None,
-                        (best_times.get(driver) / pole_time - 1) * 100 if best_times.get(driver) is not None and pole_time is not None else None,
+                        gap_sec,
+                        gap_pct,
                         teammate_gap,
                         momentum,
                         cons_momentum,


### PR DESCRIPTION
## Summary
- default qualifying gap deltas to 5 seconds/percent when missing
- give constructor momentum a 0.0 sentinel
- document these sentinel values in the README

## Testing
- `python -m py_compile process_data.py fetch_data.py data_collection.py`
- `python process_data.py` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_684cb2a4728c8331829708e4430e76a9