### PR TITLE
Add persistence for CatBoost podium model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 jolpica_f1_cache/
 catboost_info/
+__pycache__/
+podium_model.cbm

--- a/README.md
+++ b/README.md
@@ -69,10 +69,13 @@ Refer to the markdown files in the `endpoints` folder for details about optional
 
 Use `predict_top3.py` to predict the top three finishers for a specific race. The
 script trains only on races completed prior to the chosen round and relies solely
-on information available up to qualifying of that event.
+on information available up to qualifying of that event. The trained CatBoost
+model is saved to disk so subsequent predictions can reuse it.
 
 ```bash
 python predict_top3.py --season 2025 --round 9
 ```
 
 The command above predicts the Spanish Grand Prix (round 9) for the 2025 season.
+Specify `--model-path` to control where the model is stored and use
+`--force-train` to retrain even if the file exists.

--- a/predict_top3.py
+++ b/predict_top3.py
@@ -176,6 +176,17 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Predict F1 podium for a race")
     parser.add_argument("--season", type=int, required=True, help="Season year")
     parser.add_argument("--round", type=int, required=True, help="Round number")
+    parser.add_argument(
+        "--model-path",
+        type=Path,
+        default=Path(__file__).with_name("podium_model.cbm"),
+        help="Path to save/load the trained CatBoost model",
+    )
+    parser.add_argument(
+        "--force-train",
+        action="store_true",
+        help="Retrain model even if a saved one exists",
+    )
     args = parser.parse_args()
 
     csv_path = Path(__file__).with_name("f1_data_2022_to_present.csv")
@@ -197,8 +208,12 @@ def main() -> None:
     params["class_weights"] = [1.0, (y == 0).sum() / (y == 1).sum()]
 
     model = CatBoostClassifier(**params)
-    train_pool = Pool(X, y, cat_features=cat_idx)
-    model.fit(train_pool)
+    if not args.force_train and args.model_path.exists():
+        model.load_model(args.model_path)
+    else:
+        train_pool = Pool(X, y, cat_features=cat_idx)
+        model.fit(train_pool)
+        model.save_model(args.model_path)
 
     features = build_features(args.season, args.round, train_df)
     preds = model.predict_proba(Pool(features, cat_features=cat_idx))[:, 1]


### PR DESCRIPTION
## Summary
- allow saving/loading the CatBoost model when predicting
- ignore pycache files and saved model artifact
- update README with instructions for using the cached model

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684dbe5c88f08331bee018e2b55cc234