### PR TITLE
Enable CSV output for race predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,5 @@ python predict_top3.py --season 2025 --round 9
 ```
 
 The command above predicts the Spanish Grand Prix (round 9) for the 2025 season.
+It also writes a CSV `prediction_data_<season>_<round>.csv` containing the
+features and probabilities used to determine the podium.

--- a/predict_top3.py
+++ b/predict_top3.py
@@ -203,7 +203,16 @@ def main() -> None:
     features = build_features(args.season, args.round, train_df)
     preds = model.predict_proba(Pool(features, cat_features=cat_idx))[:, 1]
     features["prob"] = preds
-    top3 = features.sort_values("prob", ascending=False).head(3)["driver_id"].tolist()
+    top3 = (
+        features.sort_values("prob", ascending=False)
+        .head(3)["driver_id"]
+        .tolist()
+    )
+
+    output_csv = Path(__file__).with_name(
+        f"prediction_data_{args.season}_{args.round}.csv"
+    )
+    features.to_csv(output_csv, index=False)
 
     print("Predicted podium drivers:")
     for drv in top3:


### PR DESCRIPTION
## Summary
- persist prediction features to `prediction_data_<season>_<round>.csv`
- document the generated CSV in the README

## Testing
- `python -m py_compile predict_top3.py`


------
https://chatgpt.com/codex/tasks/task_b_684dc1e78ec08331ac333a84685ac19e