### PR TITLE
Enable export of all training data for predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,6 @@ python predict_top3.py --season 2025 --round 9
 ```
 
 The command above predicts the Spanish Grand Prix (round 9) for the 2025 season.
+It also writes a CSV `prediction_data_<season>_<round>.csv` containing all
+training data from 2022 onward plus the qualifying features for the chosen race,
+with predicted probabilities for each driver in that event.


### PR DESCRIPTION
## Summary
- add training data to the prediction CSV
- mention the enriched CSV output in the README

## Testing
- `python -m py_compile predict_top3.py`


------
https://chatgpt.com/codex/tasks/task_b_684dc1e78ec08331ac333a84685ac19e