### PR TITLE
Show podium probabilities

### DIFF
--- a/predict_top3.py
+++ b/predict_top3.py
@@ -203,11 +203,12 @@ def main() -> None:
     features = build_features(args.season, args.round, train_df)
     preds = model.predict_proba(Pool(features, cat_features=cat_idx))[:, 1]
     features["prob"] = preds
-    top3 = features.sort_values("prob", ascending=False).head(3)["driver_id"].tolist()
+
+    top3_df = features.sort_values("prob", ascending=False).head(3)
 
     print("Predicted podium drivers:")
-    for drv in top3:
-        print(drv)
+    for _, row in top3_df.iterrows():
+        print(f"{row['driver_id']}: {row['prob']:.3f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- display each driver's probability of finishing on the podium in `predict_top3.py`

## Testing
- `python -m py_compile predict_top3.py`
- `python predict_top3.py --season 2023 --round 5` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_684dcd09257c83318615a72dc7dbb882