### PR TITLE
Update prediction features for overtakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Raw responses are downloaded with `fetch_data.py` and stored under `jolpica_f1_c
 - driver momentum over the last three races (0.0 for the first six rounds)
 - constructor momentum over the last three races (0.0 for the first six rounds)
 - pit stop difficulty index
+- overtakes made per driver in the race
+- overtakes lost per driver in the race
+- net overtakes (made minus lost)
 
 The script writes the prepared dataset to `f1_data_2022_to_present.csv` in the current directory.
 

--- a/predict_top3.py
+++ b/predict_top3.py
@@ -166,6 +166,10 @@ def build_features(season: int, round_no: int, hist_df: pd.DataFrame) -> pd.Data
                 driver_momentum=momentum,
                 constructor_momentum=cons_momentum,
                 pit_stop_difficulty=mean_psd,
+                # overtakes not available pre‑race
+                overtakes_made=0,
+                overtakes_lost=0,
+                net_overtakes=0,
             )
         )
 


### PR DESCRIPTION
## Summary
- support new `overtakes_*` columns when building prediction features
- document overtakes fields in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684de04966008331a08da353f87cc6c9