### PR TITLE
Add overtake difficulty feature

### DIFF
--- a/data_collection.py
+++ b/data_collection.py
@@ -1,9 +1,29 @@
 from datetime import datetime
+from pathlib import Path
+import argparse
 
 from fetch_data import fetch_data
 from process_data import prepare_dataset
 
+
+def refresh_lap_cache() -> None:
+    """Remove cached lap data files."""
+    cache_dir = Path("jolpica_f1_cache")
+    for file in cache_dir.rglob("*_laps.json"):
+        file.unlink(missing_ok=True)
+
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--refresh-laps",
+        action="store_true",
+        help="Invalidate cached lap data before fetching",
+    )
+    args = parser.parse_args()
+
+    if args.refresh_laps:
+        refresh_lap_cache()
+
     current_year = datetime.now().year
     fetch_data(2022, current_year)
     prepare_dataset(2022, current_year, "f1_data_2022_to_present.csv")

--- a/predict_top3.py
+++ b/predict_top3.py
@@ -77,6 +77,10 @@ def build_features(season: int, round_no: int, hist_df: pd.DataFrame) -> pd.Data
     )
 
     mean_psd = hist_df["pit_stop_difficulty"].mean()
+    diff_map = (
+        hist_df.groupby("circuit_id")["overtake_difficulty"].mean().to_dict()
+    )
+    diff_fallback = hist_df["overtake_difficulty"].mean()
 
     rows = []
     for res in results:
@@ -166,6 +170,7 @@ def build_features(season: int, round_no: int, hist_df: pd.DataFrame) -> pd.Data
                 driver_momentum=momentum,
                 constructor_momentum=cons_momentum,
                 pit_stop_difficulty=mean_psd,
+                overtake_difficulty=diff_map.get(circuit_id, diff_fallback),
             )
         )
 

--- a/tests/test_overtake_feature.py
+++ b/tests/test_overtake_feature.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fetch_data import get_laps, get_pitstops, get_status
+from process_data import detect_passes, circuit_difficulty, race_pass_df
+from model_catboost_final import main as train_model
+
+
+@pytest.mark.parametrize(
+    "season,round_no,expected,delta",
+    [
+        (2023, 7, 36, 5),
+        (2023, 1, 80, 10),
+    ],
+)
+def test_pass_counts(season, round_no, expected, delta):
+    laps = get_laps(season, round_no)
+    pits = get_pitstops(season, round_no)
+    status = get_status(season, round_no)
+    passes = detect_passes(laps, pits, status)
+    assert abs(passes - expected) <= delta
+
+
+def test_shap_importance():
+    train_model()
+
+


### PR DESCRIPTION
## Summary
- extend data fetcher with helpers for laps, pitstops and status
- add pass detection and overtake difficulty computation
- expose refresh flag in collection script
- support new feature in model training and prediction
- add regression tests for pass counts and SHAP importance

## Testing
- `pytest -q` *(fails: ProxyError, SHAP importance too low)*

------
https://chatgpt.com/codex/tasks/task_b_684e0637599c8331b6f77c0dadafbf85