### PR TITLE
Add overtaking difficulty feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Raw responses are downloaded with `fetch_data.py` and stored under `jolpica_f1_c
 - driver momentum over the last three races (0.0 for the first six rounds)
 - constructor momentum over the last three races (0.0 for the first six rounds)
 - pit stop difficulty index
+- overtaking difficulty per circuit
 
 The script writes the prepared dataset to `f1_data_2022_to_present.csv` in the current directory.
 

--- a/feature_utils.py
+++ b/feature_utils.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from pathlib import Path
+
+
+def add_overtaking_difficulty(df: pd.DataFrame) -> pd.DataFrame:
+    """Merge overtaking difficulty by circuit_id and fill missing values."""
+    csv_path = Path(__file__).with_name("overtaking_difficulty.csv")
+    odf = pd.read_csv(csv_path)
+    df = df.merge(
+        odf[["circuit_id", "overtaking_difficulty"]],
+        on="circuit_id",
+        how="left",
+    )
+    median_value = odf["overtaking_difficulty"].median()
+    df["overtaking_difficulty"] = df["overtaking_difficulty"].fillna(median_value)
+    return df

--- a/model_catboost_final.py
+++ b/model_catboost_final.py
@@ -21,6 +21,8 @@ Dependencies:
 import numpy as np
 import pandas as pd
 from pathlib import Path
+
+from feature_utils import add_overtaking_difficulty
 from catboost import CatBoostClassifier, Pool
 from sklearn.model_selection import GroupKFold
 from sklearn.metrics import (
@@ -47,6 +49,7 @@ MODEL_PARAMS = dict(
 # -------------------- Load data --------------------
 csv_path = Path(__file__).with_name("f1_data_2022_to_present.csv")
 df = pd.read_csv(csv_path)
+df = add_overtaking_difficulty(df)
 
 df["top3_flag"] = (df["finishing_position"] <= 3).astype(int)
 df["group"] = df["season_year"].astype(str) + "-" + df["round_number"].astype(str)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -5,11 +5,13 @@ from catboost import CatBoostClassifier, Pool
 
 from predict_top3 import build_features
 from model_catboost_final import MODEL_PARAMS
+from feature_utils import add_overtaking_difficulty
 
 
 def load_history():
     csv_path = Path(__file__).with_name("f1_data_2022_to_present.csv")
     df = pd.read_csv(csv_path)
+    df = add_overtaking_difficulty(df)
     df["top3_flag"] = (df["finishing_position"] <= 3).astype(int)
     df["group"] = df["season_year"].astype(str) + "-" + df["round_number"].astype(str)
     return df

--- a/threshold_scan_final.py
+++ b/threshold_scan_final.py
@@ -14,6 +14,8 @@ pip install catboost scikit‑learn pandas numpy
 import numpy as np
 import pandas as pd
 from pathlib import Path
+
+from feature_utils import add_overtaking_difficulty
 from catboost import CatBoostClassifier, Pool
 from sklearn.model_selection import GroupKFold
 from sklearn.metrics import f1_score, precision_recall_fscore_support
@@ -36,6 +38,7 @@ CSV = Path(__file__).with_name("f1_data_2022_to_present.csv")
 
 # ---------- data ----------
 df = pd.read_csv(CSV)
+df = add_overtaking_difficulty(df)
 df["top3_flag"] = (df["finishing_position"] <= 3).astype(int)
 df["group"] = df["season_year"].astype(str) + "-" + df["round_number"].astype(str)
 

--- a/tune_catboost_optuna_cpu.py
+++ b/tune_catboost_optuna_cpu.py
@@ -7,6 +7,8 @@ Run:
 
 import argparse, optuna, numpy as np, pandas as pd
 from pathlib import Path
+
+from feature_utils import add_overtaking_difficulty
 from catboost import CatBoostClassifier, Pool
 from sklearn.model_selection import GroupKFold
 from sklearn.metrics import f1_score
@@ -19,6 +21,7 @@ args = parser.parse_args()
 
 # ---------- Data ----------
 df = pd.read_csv(Path(__file__).with_name('f1_data_2022_to_present.csv'))
+df = add_overtaking_difficulty(df)
 df['top3_flag'] = (df.finishing_position <= 3).astype(int)
 df['group'] = df.season_year.astype(str) + '-' + df.round_number.astype(str)
 X = df.drop(columns=['finishing_position', 'top3_flag', 'group'])

--- a/tune_catboost_optuna_gpu.py
+++ b/tune_catboost_optuna_gpu.py
@@ -7,6 +7,8 @@ Run:
 
 import argparse, optuna, numpy as np, pandas as pd
 from pathlib import Path
+
+from feature_utils import add_overtaking_difficulty
 from catboost import CatBoostClassifier, Pool
 from sklearn.model_selection import GroupKFold
 from sklearn.metrics import f1_score
@@ -18,6 +20,7 @@ args = parser.parse_args()
 
 # ---------- Data ----------
 df = pd.read_csv(Path(__file__).with_name('f1_data_2022_to_present.csv'))
+df = add_overtaking_difficulty(df)
 df['top3_flag'] = (df.finishing_position <= 3).astype(int)
 df['group'] = df.season_year.astype(str) + '-' + df.round_number.astype(str)
 X = df.drop(columns=['finishing_position', 'top3_flag', 'group'])


### PR DESCRIPTION
## Summary
- add utility `feature_utils.add_overtaking_difficulty`
- incorporate overtaking difficulty into training and prediction scripts
- update Streamlit app and tuning scripts to merge new feature
- document overtaking difficulty feature in README

## Testing
- `python -m py_compile feature_utils.py model_catboost_final.py threshold_scan_final.py tune_catboost_optuna_cpu.py tune_catboost_optuna_gpu.py predict_top3.py streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_b_684e1bf9eb40833180d67330cf1c20ad