### PR TITLE
Add probability to podium predictions

### DIFF
--- a/predict_top3.py
+++ b/predict_top3.py
@@ -206,11 +206,11 @@ def main() -> None:
     features = build_features(args.season, args.round, train_df)
     preds = model.predict_proba(Pool(features, cat_features=cat_idx))[:, 1]
     features["prob"] = preds
-    top3 = features.sort_values("prob", ascending=False).head(3)["driver_id"].tolist()
+    top3 = features.sort_values("prob", ascending=False).head(3)
 
     print("Predicted podium drivers:")
-    for drv in top3:
-        print(drv)
+    for _, row in top3.iterrows():
+        print(f"{row['driver_id']}: {row['prob']:.3f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- show probability score for each predicted podium driver

## Testing
- `python -m py_compile predict_top3.py`

------
https://chatgpt.com/codex/tasks/task_b_684e274ce2d48331814c93387ab787c0