### PR TITLE
Align grid penalty handling with build_features

### DIFF
--- a/feature_importance.py
+++ b/feature_importance.py
@@ -15,7 +15,15 @@ def load_data() -> tuple[pd.DataFrame, pd.Series, list[int]]:
     df = pd.read_csv(csv_path)
     df["top3_flag"] = (df["finishing_position"] <= 3).astype(int)
 
-    X = df.drop(columns=["finishing_position", "top3_flag"])
+    X = df.drop(
+        columns=[
+            "finishing_position",
+            "top3_flag",
+            "grid_penalty_places",
+            "grid_penalty_flag",
+            "grid_bonus_flag",
+        ]
+    )
     y = df["top3_flag"]
     cat_cols = ["circuit_id", "driver_id", "constructor_id"]
     cat_idx = [X.columns.get_loc(c) for c in cat_cols]

--- a/model_catboost_final.py
+++ b/model_catboost_final.py
@@ -51,7 +51,16 @@ df = pd.read_csv(csv_path)
 df["top3_flag"] = (df["finishing_position"] <= 3).astype(int)
 df["group"] = df["season_year"].astype(str) + "-" + df["round_number"].astype(str)
 
-X = df.drop(columns=["finishing_position", "top3_flag", "group"])
+X = df.drop(
+    columns=[
+        "finishing_position",
+        "top3_flag",
+        "group",
+        "grid_penalty_places",
+        "grid_penalty_flag",
+        "grid_bonus_flag",
+    ]
+)
 y = df["top3_flag"].values
 groups = df["group"].values
 

--- a/predict_top3.py
+++ b/predict_top3.py
@@ -152,9 +152,6 @@ def build_features(season: int, round_no: int, hist_df: pd.DataFrame) -> pd.Data
                 circuit_id=circuit_id,
                 driver_id=drv,
                 starting_grid_position=grid_pos,
-                grid_penalty_places=penalty_places,
-                grid_penalty_flag=penalty_flag,
-                grid_bonus_flag=bonus_flag,
                 q2_flag=q2_flag,
                 q3_flag=q3_flag,
                 driver_points_scored=driver_points,
@@ -194,7 +191,16 @@ def main() -> None:
         | ((df["season_year"] == args.season) & (df["round_number"] < args.round))
     ]
 
-    X = train_df.drop(columns=["finishing_position", "top3_flag", "group"])
+    X = train_df.drop(
+        columns=[
+            "finishing_position",
+            "top3_flag",
+            "group",
+            "grid_penalty_places",
+            "grid_penalty_flag",
+            "grid_bonus_flag",
+        ]
+    )
     y = train_df["top3_flag"].values
     cat_cols = ["circuit_id", "driver_id", "constructor_id"]
     cat_idx = [X.columns.get_loc(c) for c in cat_cols]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -16,7 +16,16 @@ def load_history():
 
 
 def train_model(train_df):
-    X = train_df.drop(columns=["finishing_position", "top3_flag", "group"])
+    X = train_df.drop(
+        columns=[
+            "finishing_position",
+            "top3_flag",
+            "group",
+            "grid_penalty_places",
+            "grid_penalty_flag",
+            "grid_bonus_flag",
+        ]
+    )
     y = train_df["top3_flag"].values
     cat_cols = ["circuit_id", "driver_id", "constructor_id"]
     cat_idx = [X.columns.get_loc(c) for c in cat_cols]
@@ -31,16 +40,17 @@ def train_model(train_df):
     imp = model.get_feature_importance(pool)
     feat_imp = pd.Series(imp, index=X.columns).sort_values(ascending=False)
 
-    return model, cat_idx, feat_imp
+    return model, cat_idx, feat_imp, X.columns
 
 
 def predict_top3_streamlit(season: int, round_no: int, hist_df: pd.DataFrame):
     train_df = hist_df[(hist_df["season_year"] < season) |
                        ((hist_df["season_year"] == season) & (hist_df["round_number"] < round_no))]
 
-    model, cat_idx, feat_imp = train_model(train_df)
+    model, cat_idx, feat_imp, cols = train_model(train_df)
 
     features = build_features(season, round_no, train_df)
+    features = features[cols]
     probs = model.predict_proba(Pool(features, cat_features=cat_idx))[:, 1]
     features["prob"] = probs
     return features.sort_values("prob", ascending=False), feat_imp

--- a/threshold_scan_final.py
+++ b/threshold_scan_final.py
@@ -40,7 +40,16 @@ if 'top3_flag' not in df.columns:
 if 'group' not in df.columns:
     df['group'] = df['season_year'].astype(str) + '-' + df['round_number'].astype(str)
 
-X = df.drop(columns=['finishing_position','top3_flag','group'])
+X = df.drop(
+    columns=[
+        'finishing_position',
+        'top3_flag',
+        'group',
+        'grid_penalty_places',
+        'grid_penalty_flag',
+        'grid_bonus_flag',
+    ]
+)
 y = df['top3_flag'].values
 groups = df['group'].values
 cat_idx = [X.columns.get_loc(c) for c in ['circuit_id','driver_id','constructor_id']]

--- a/tune_catboost_optuna_cpu.py
+++ b/tune_catboost_optuna_cpu.py
@@ -21,7 +21,16 @@ args = parser.parse_args()
 df = pd.read_csv(Path(__file__).with_name('f1_data_2022_to_present.csv'))
 df['top3_flag'] = (df.finishing_position <= 3).astype(int)
 df['group'] = df.season_year.astype(str) + '-' + df.round_number.astype(str)
-X = df.drop(columns=['finishing_position', 'top3_flag', 'group'])
+X = df.drop(
+    columns=[
+        'finishing_position',
+        'top3_flag',
+        'group',
+        'grid_penalty_places',
+        'grid_penalty_flag',
+        'grid_bonus_flag',
+    ]
+)
 y = df.top3_flag.values
 groups = df.group.values
 cat_idx = [X.columns.get_loc(c) for c in ['circuit_id', 'driver_id', 'constructor_id']]

--- a/tune_catboost_optuna_gpu.py
+++ b/tune_catboost_optuna_gpu.py
@@ -20,7 +20,16 @@ args = parser.parse_args()
 df = pd.read_csv(Path(__file__).with_name('f1_data_2022_to_present.csv'))
 df['top3_flag'] = (df.finishing_position <= 3).astype(int)
 df['group'] = df.season_year.astype(str) + '-' + df.round_number.astype(str)
-X = df.drop(columns=['finishing_position', 'top3_flag', 'group'])
+X = df.drop(
+    columns=[
+        'finishing_position',
+        'top3_flag',
+        'group',
+        'grid_penalty_places',
+        'grid_penalty_flag',
+        'grid_bonus_flag',
+    ]
+)
 y = df.top3_flag.values
 groups = df.group.values
 cat_idx = [X.columns.get_loc(c) for c in ['circuit_id', 'driver_id', 'constructor_id']]


### PR DESCRIPTION
## Summary
- drop all grid penalty columns for training and prediction
- update helper scripts to remove and ignore these columns
- retrain the model after changes

## Testing
- `python model_catboost_final.py > /tmp/train.log && tail -n 20 /tmp/train.log`
- `python -m py_compile predict_top3.py streamlit_app.py model_catboost_final.py threshold_scan_final.py tune_catboost_optuna_cpu.py tune_catboost_optuna_gpu.py feature_importance.py`

------
https://chatgpt.com/codex/tasks/task_b_684ed0870530833188733416f148a81f