### PR TITLE
Add DNF rate features

### DIFF
--- a/model_catboost_final.py
+++ b/model_catboost_final.py
@@ -58,7 +58,7 @@ df = pd.read_csv(csv_path)
 df["top3_flag"] = (df["finishing_position"] <= 3).astype(int)
 df["group"] = df["season_year"].astype(str) + "-" + df["round_number"].astype(str)
 
-X = df.drop(columns=["finishing_position", "top3_flag", "group"])
+X = df.drop(columns=["finishing_position", "dnf_flag", "top3_flag", "group"])
 y = df["top3_flag"].values
 groups = df["group"].values
 


### PR DESCRIPTION
## Summary
- compute DNF rate over previous races when preparing the dataset
- incorporate driver and constructor DNF rates in prediction features
- ignore `dnf_flag` column when training models

## Testing
- `python3 -m py_compile process_data.py predict_top3.py model_catboost_final.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f464f74b4833191f524bd84a447ad