### PR TITLE
Fix pit stop difficulty leakage

### DIFF
--- a/predict_top3.py
+++ b/predict_top3.py
@@ -85,7 +85,11 @@ def build_features(season: int, round_no: int, hist_df: pd.DataFrame) -> pd.Data
         .to_dict()
     )
 
-    mean_psd = hist_df["pit_stop_difficulty"].mean()
+    circuit_psd = hist_df.loc[
+        hist_df["circuit_id"] == circuit_id, "pit_stop_difficulty"
+    ].mean()
+    overall_psd = hist_df["pit_stop_difficulty"].mean()
+    mean_psd = circuit_psd if not pd.isna(circuit_psd) else overall_psd
     weather = fetch_weather(season, round_no)
 
     rows = []


### PR DESCRIPTION
## Summary
- compute historical pit stop difficulty in `process_data.prepare_dataset`
- use circuit-specific pit stop difficulty in prediction features

## Testing
- `python -m py_compile process_data.py predict_top3.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_b_684f46405fa08331b5a17d42bab94454