### PR TITLE
Use forecasted weather data

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ This repository contains utilities to download Formula 1 race data using the Jol
 - driver DNF rate (rolling window)
 - constructor DNF rate (rolling window)
 - pit stop difficulty index
-- mean temperature during the race window
-- total precipitation during the race window
-- mean humidity during the race window
-- mean wind speed during the race window
+- mean temperature forecast for the race window
+- total precipitation forecast for the race window
+- mean humidity forecast for the race window
+- mean wind speed forecast for the race window
+
+The weather metrics use the forecast that would have been available at
+qualifying time. For completed races this is approximated using a
+10-year historical average for the same location and time window.
 
 The script writes the prepared dataset to `f1_data_2022_to_present.csv` in the current directory.
 

--- a/process_data.py
+++ b/process_data.py
@@ -90,12 +90,18 @@ def get_last_round(csv_file: str):
 
 
 def load_weather(season: int, round_no: int):
-    """Load cached weather features for a race."""
+    """Load cached weather forecast features for a race."""
     cache_file = os.path.join("weather_cache", f"weather_{season}_{round_no}.json")
     if os.path.exists(cache_file):
         with open(cache_file, encoding="utf-8") as f:
             return json.load(f)
-    return {}
+    # If the file is missing, attempt to fetch and cache it
+    try:
+        from fetch_data import fetch_weather
+
+        return fetch_weather(season, round_no)
+    except Exception:
+        return {}
 
 
 def prepare_dataset(start_season: int, end_season: int, output_file: str):


### PR DESCRIPTION
## Summary
- compute historical average weather or forecast at qualifying when caching weather data
- call `fetch_weather` from `process_data` if the cached file is missing
- document the use of weather forecasts in the dataset

## Testing
- `python -m py_compile fetch_data.py process_data.py predict_top3.py data_collection.py model_catboost_final.py threshold_scan_final.py`
- `python model_catboost_final.py > /tmp/model_train.log && tail -n 12 /tmp/model_train.log`

------
https://chatgpt.com/codex/tasks/task_b_684ff3df948c8331b1dfa0ec9a5a436c