### PR TITLE
Switch to TimeSeriesSplit

### DIFF
--- a/model_catboost_final.py
+++ b/model_catboost_final.py
@@ -1,7 +1,7 @@
 """
 Final CatBoost model for predicting top‑3 podium finishes in Formula 1.
 
-Performance target: F1 ≥ 0.80 and recall ≥ 0.90 (5‑fold GroupKFold)
+Performance target: F1 ≥ 0.80 and recall ≥ 0.90 (5‑fold TimeSeriesSplit)
 
 Usage:
     python model_catboost_final.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 from catboost import CatBoostClassifier, Pool
-from sklearn.model_selection import GroupKFold
+from sklearn.model_selection import TimeSeriesSplit
 from sklearn.metrics import (
     accuracy_score,
     precision_recall_fscore_support,
@@ -56,7 +56,6 @@ if "dnf_flag" in df.columns:
 
 X = df.drop(columns=drop_cols)
 y = df["top3_flag"].values
-groups = df["group"].values
 
 cat_cols = ["circuit_id", "driver_id", "constructor_id"]
 cat_idx = [X.columns.get_loc(c) for c in cat_cols]
@@ -64,10 +63,10 @@ cat_idx = [X.columns.get_loc(c) for c in cat_cols]
 MODEL_PARAMS["class_weights"] = [1.0, (y == 0).sum() / (y == 1).sum()]
 
 # -------------------- Cross‑validation --------------------
-gkf = GroupKFold(n_splits=5)
+tscv = TimeSeriesSplit(n_splits=5)
 metrics = {k: [] for k in ["acc", "prec", "rec", "f1", "auc"]}
 
-for fold, (train_idx, test_idx) in enumerate(gkf.split(X, y, groups), 1):
+for fold, (train_idx, test_idx) in enumerate(tscv.split(X), 1):
     model = CatBoostClassifier(**MODEL_PARAMS)
 
     train_pool = Pool(X.iloc[train_idx], y[train_idx], cat_features=cat_idx)

--- a/threshold_scan_final.py
+++ b/threshold_scan_final.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 from catboost import CatBoostClassifier, Pool
-from sklearn.model_selection import GroupKFold
+from sklearn.model_selection import TimeSeriesSplit
 from sklearn.metrics import precision_recall_fscore_support, roc_auc_score
 
 # ---------- CLI args ----------
@@ -42,14 +42,13 @@ if 'group' not in df.columns:
 
 X = df.drop(columns=['finishing_position','top3_flag','group'])
 y = df['top3_flag'].values
-groups = df['group'].values
 cat_idx = [X.columns.get_loc(c) for c in ['circuit_id','driver_id','constructor_id']]
 
 # ---------- collect OOF probabilities ----------
 y_probs = np.zeros_like(y, dtype=float)
 
-gkf = GroupKFold(n_splits=5)
-for train_idx, test_idx in gkf.split(X, y, groups):
+tscv = TimeSeriesSplit(n_splits=5)
+for train_idx, test_idx in tscv.split(X):
     train_pool = Pool(X.iloc[train_idx], y[train_idx], cat_features=cat_idx)
     valid_pool = Pool(X.iloc[test_idx],  y[test_idx],  cat_features=cat_idx)
     model = CatBoostClassifier(**MODEL_PARAMS)

--- a/tune_catboost_optuna_gpu.py
+++ b/tune_catboost_optuna_gpu.py
@@ -8,7 +8,7 @@ Run:
 import argparse, optuna, numpy as np, pandas as pd
 from pathlib import Path
 from catboost import CatBoostClassifier, Pool
-from sklearn.model_selection import GroupKFold
+from sklearn.model_selection import TimeSeriesSplit
 from sklearn.metrics import f1_score
 
 parser = argparse.ArgumentParser()
@@ -25,9 +25,8 @@ if 'dnf_flag' in df.columns:
     drop_cols.append('dnf_flag')
 X = df.drop(columns=drop_cols)
 y = df.top3_flag.values
-groups = df.group.values
 cat_idx = [X.columns.get_loc(c) for c in ['circuit_id', 'driver_id', 'constructor_id']]
-gkf = GroupKFold(5)
+tscv = TimeSeriesSplit(n_splits=5)
 
 def objective(trial):
     params = {
@@ -49,7 +48,7 @@ def objective(trial):
 
     thr = trial.suggest_float('thr', 0.40, 0.55)
     f1s = []
-    for tr, te in gkf.split(X, y, groups):
+    for tr, te in tscv.split(X):
         model = CatBoostClassifier(**params)
         model.fit(Pool(X.iloc[tr], y[tr], cat_features=cat_idx),
                   eval_set=Pool(X.iloc[te], y[te], cat_features=cat_idx),


### PR DESCRIPTION
## Summary
- use `TimeSeriesSplit` instead of `GroupKFold` in modeling scripts

## Testing
- `python -m py_compile model_catboost_final.py tune_catboost_optuna_gpu.py tune_catboost_optuna_cpu.py threshold_scan_final.py`

------
https://chatgpt.com/codex/tasks/task_b_68507f9bd9fc8331bf5122b59dc85aff