### PR TITLE
Add Overtake Difficulty Index feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ qualifying time. For completed races this is approximated using a
 
 The script writes the prepared dataset to `f1_data_2022_to_present.csv` in the current directory.
 
+### ODI build (2020-present) & use (2022-present)
+
+An additional Overtake Difficulty Index (ODI) is derived from lap timing data.
+Run `compute_odi.py` before generating the CSV:
+
+```bash
+python compute_odi.py --start 2020 --end <YEAR-1>
+```
+
+This scans seasons 2020 up to `YEAR-1` and stores a lookup under
+`odi_cache/odi_<YEAR-1>.json`. `process_data.py` automatically reads the
+lookup for each season (using the previous year) and appends two columns:
+`odi_raw` and `grid_odi_mult`.
+
 ### Requirements
 
 - Python 3.8+

--- a/compute_odi.py
+++ b/compute_odi.py
@@ -1,0 +1,82 @@
+import argparse
+import json
+import os
+import statistics
+
+from fetch_data import fetch_round_data, log
+
+
+def compute_odi(start: int, end: int) -> None:
+    log(f"🔄 scanning overtakes {start}-{end}")
+    raw = {}
+    max_opl = 0.0
+    for season in range(start, end + 1):
+        round_no = 1
+        while True:
+            data = fetch_round_data(season, round_no)
+            if data is None:
+                break
+            laps = data.get("laps", [])
+            if not laps:
+                round_no += 1
+                continue
+            pitstops = data.get("pitstops", [])
+            pit_laps = {}
+            for p in pitstops:
+                drv = p.get("driverId")
+                lap = p.get("lap")
+                if drv and lap:
+                    pit_laps.setdefault(drv, set()).add(int(lap))
+
+            positions = {}
+            for lap in laps:
+                num = int(lap.get("number"))
+                positions[num] = {t["driverId"]: int(t["position"]) for t in lap.get("Timings", [])}
+
+            lap_nums = sorted(positions)
+            overtakes = 0
+            for i in range(1, len(lap_nums)):
+                prev = positions[lap_nums[i - 1]]
+                curr = positions[lap_nums[i]]
+                lap_id = lap_nums[i]
+                for drv, pos in curr.items():
+                    if lap_id in pit_laps.get(drv, set()):
+                        continue
+                    prev_pos = prev.get(drv)
+                    if prev_pos is None:
+                        continue
+                    delta = prev_pos - pos
+                    if delta > 0:
+                        overtakes += delta
+            laps_total = lap_nums[-1] if lap_nums else 0
+            if laps_total > 0:
+                opl = overtakes / laps_total
+                circ = data["circuit_id"]
+                raw.setdefault(circ, {})[season] = opl
+                max_opl = max(max_opl, opl)
+            round_no += 1
+
+    hist_start = max(2020, end - 4)
+    seasons_hist = list(range(hist_start, end + 1))
+    lookup = {}
+    for circ, by_season in raw.items():
+        vals = [by_season[s] for s in seasons_hist if s in by_season]
+        if not vals:
+            continue
+        med = statistics.median(vals)
+        odi_raw = 1 - (med / max_opl) if max_opl else 0.0
+        lookup[circ] = odi_raw
+
+    os.makedirs("odi_cache", exist_ok=True)
+    out_file = os.path.join("odi_cache", f"odi_{end}.json")
+    with open(out_file, "w", encoding="utf-8") as f:
+        json.dump(lookup, f, indent=2)
+    log(f"✅ wrote ODI for {len(lookup)} circuits to {out_file}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--start", type=int, required=True)
+    parser.add_argument("--end", type=int, required=True)
+    args = parser.parse_args()
+    compute_odi(args.start, args.end)

--- a/tests/test_odi.py
+++ b/tests/test_odi.py
@@ -1,0 +1,91 @@
+import csv
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import process_data
+import compute_odi
+
+
+def test_process_data_uses_previous_year(tmp_path, monkeypatch):
+    odi_dir = tmp_path / "odi_cache"
+    odi_dir.mkdir()
+    with open(odi_dir / "odi_2021.json", "w") as f:
+        json.dump({"silverstone": 0.3}, f)
+
+    sample = {
+        "circuit_id": "silverstone",
+        "results": [
+            {
+                "Driver": {"driverId": "ham"},
+                "Constructor": {"constructorId": "mer"},
+                "position": "1",
+                "status": "Finished",
+            }
+        ],
+        "driver_standings": [{"Driver": {"driverId": "ham"}, "points": "25", "position": "1"}],
+        "constructor_standings": [{"Constructor": {"constructorId": "mer"}, "points": "25", "position": "1"}],
+        "qualifying": [{"Driver": {"driverId": "ham"}, "Q1": "1:20.0", "position": "1"}],
+        "pitstops": [],
+        "laps": [],
+    }
+
+    def fake_fetch(season, rnd):
+        if season == 2022 and rnd == 1:
+            return sample
+        return None
+
+    monkeypatch.setattr(process_data, "fetch_round_data", fake_fetch)
+    monkeypatch.setattr(process_data, "log", lambda msg: None)
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        process_data.prepare_dataset(2022, 2022, "out.csv")
+    finally:
+        os.chdir(cwd)
+
+    with open(tmp_path / "out.csv") as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        row = next(reader)
+
+    assert header[-2:] == ["odi_raw", "grid_odi_mult"]
+    assert row[-2:] == ["0.3", "0.3"]
+
+
+def test_compute_odi_output(tmp_path, monkeypatch):
+    laps = [
+        {"number": "1", "Timings": [{"driverId": "a", "position": "1"}, {"driverId": "b", "position": "2"}]},
+        {"number": "2", "Timings": [{"driverId": "b", "position": "1"}, {"driverId": "a", "position": "2"}]},
+    ]
+    sample = {
+        "circuit_id": "foo",
+        "results": [],
+        "pitstops": [],
+        "laps": laps,
+    }
+
+    def fake_fetch(season, rnd):
+        if rnd == 1:
+            return sample
+        return None
+
+    monkeypatch.setattr(compute_odi, "fetch_round_data", fake_fetch)
+    monkeypatch.setattr(compute_odi, "log", lambda msg: None)
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        compute_odi.compute_odi(2020, 2021)
+    finally:
+        os.chdir(cwd)
+
+    out_file = tmp_path / "odi_cache" / "odi_2021.json"
+    with open(out_file) as f:
+        data = json.load(f)
+
+    assert data["foo"] == 0.0
+


### PR DESCRIPTION
## Summary
- add compute_odi.py for calculating Overtake Difficulty Index
- extend cached fetch data with lap timings
- integrate ODI lookup in dataset preparation
- document how ODI is built and used
- test ODI creation and integration

## Testing
- `pytest -q`
- `python - <<'EOF'
import compute_odi

def fake_fetch(season, rnd):
    if rnd == 1:
        return {"circuit_id": "foo", "results": [], "pitstops": [], "laps": []}
    return None

compute_odi.fetch_round_data = fake_fetch
compute_odi.log = print
compute_odi.compute_odi(2020, 2024)
EOF`

------
https://chatgpt.com/codex/tasks/task_b_68517154d2a48331a4c9a4b85e65d4fa