### PR TITLE
Add driver nationality flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This repository contains utilities to download Formula 1 race data using the Jolpica F1 API. The data can be used for analytics or building predictive models.
 
+The file `nationality.json` maps each driver ID to a country flag emoji. It is
+used by the CLI tool and Streamlit app to display the driver's nationality.
+
 ## Data Collection
 
  Raw responses and weather information are downloaded with `fetch_data.py` and stored under `jolpica_f1_cache/<season>/<round>.json` and `weather_cache/`. `process_data.py` reads the cached files and builds `f1_data_2022_to_present.csv`. A helper script `data_collection.py` runs both steps. The processed data includes:
@@ -100,5 +103,5 @@ streamlit run streamlit_app.py
 ```
 
 The app lets you choose a season and round, shows the predicted probabilities
-for each driver, and visualizes global and per-driver feature importance using
-SHAP values.
+for each driver (with national flag), and visualizes global and per-driver
+feature importance using SHAP values.

--- a/predict_top3.py
+++ b/predict_top3.py
@@ -1,6 +1,7 @@
 import argparse
 from pathlib import Path
 import pandas as pd
+import json
 from catboost import CatBoostClassifier, Pool
 from model_catboost_final import MODEL_PARAMS, THRESHOLD
 from fetch_data import (
@@ -13,6 +14,9 @@ from fetch_data import (
 from process_data import parse_qual_time
 
 DNF_WINDOW = 5
+NATIONALITY_PATH = Path(__file__).with_name("nationality.json")
+with open(NATIONALITY_PATH, "r", encoding="utf-8") as f:
+    NATIONALITY = json.load(f)
 
 
 def is_dnf(status: str) -> bool:
@@ -300,7 +304,10 @@ def main() -> None:
 
     print("\n=== Voorspellingen Top 3 ===")
     for _, row in features.head(3).iterrows():
-        print(f"{row['driver_id']} → kans: {row['Podium kans']:.1f}% {'✅' if row['Voorspelling'] == 1 else ''}")
+        flag = NATIONALITY.get(row['driver_id'], '')
+        print(
+            f"{row['driver_id']} {flag} → kans: {row['Podium kans']:.1f}% {'✅' if row['Voorspelling'] == 1 else ''}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- load nationality flags in Streamlit and CLI
- display driver flag column in the Streamlit table
- print flag emoji in CLI output
- document nationality.json in README

## Testing
- `python -m py_compile streamlit_app.py predict_top3.py`
- `python predict_top3.py --season 2022 --round 1` *(fails: training process interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_6856d7a0b4a883318e95454b4f244174