### PR TITLE
Fix DNF history leak across drivers

### DIFF
--- a/process_data.py
+++ b/process_data.py
@@ -255,6 +255,7 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                     for c in cons_standings_curr
                 }
 
+                dnf_updates = []
                 for result in results:
                     driver = result["Driver"]["driverId"]
                     constructor = result["Constructor"]["constructorId"]
@@ -422,17 +423,19 @@ def prepare_dataset(start_season: int, end_season: int, output_file: str):
                         weather.get("wind_mean"),
                     ])
 
-                    # Update statistics after writing row
-                    driver_dnf_history.setdefault(driver, []).append(dnf_flag)
-                    constructor_dnf_history.setdefault(constructor, []).append(
-                        dnf_flag
-                    )
-                    if finish_pos is not None:
-                        circuit_counts[circuit_id] = circ_count + 1
-                        constructor_counts[constructor] = cons_count + 1
-                        if finish_pos <= 3:
-                            circuit_podiums[circuit_id] = circ_pods + 1
-                            constructor_podiums[constructor] = cons_pods + 1
+                    # Accumulate updates to apply after processing all results
+                    dnf_updates.append((driver, constructor, dnf_flag, finish_pos))
+
+                # Update statistics after writing all driver rows
+                for drv, cons, flag, pos in dnf_updates:
+                    driver_dnf_history.setdefault(drv, []).append(flag)
+                    constructor_dnf_history.setdefault(cons, []).append(flag)
+                    if pos is not None:
+                        circuit_counts[circuit_id] = circuit_counts.get(circuit_id, 0) + 1
+                        constructor_counts[cons] = constructor_counts.get(cons, 0) + 1
+                        if pos <= 3:
+                            circuit_podiums[circuit_id] = circuit_podiums.get(circuit_id, 0) + 1
+                            constructor_podiums[cons] = constructor_podiums.get(cons, 0) + 1
 
                 if current_psd is not None:
                     circuit_pit_history.setdefault(circuit_id, []).append(current_psd)


### PR DESCRIPTION
## Summary
- avoid updating DNF and podium statistics until all drivers of a race are processed

## Testing
- `python -m py_compile process_data.py`

------
https://chatgpt.com/codex/tasks/task_b_6857be0e397c83319c5a2b3a80f83a52