### PR TITLE
Improve parameter tuning workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,44 @@ streamlit run streamlit_app.py
 The app lets you choose a season and round, shows the predicted probabilities
 for each driver, and visualizes global and per-driver feature importance using
 SHAP values.
+
+## Advanced Model Tuning
+
+The repository includes utilities to tune the CatBoost model and optimise the
+decision threshold. A typical workflow is:
+
+1. Fetch and process the latest race data:
+
+   ```bash
+   python data_collection.py
+   ```
+
+2. Run Optuna hyper-parameter search (use `--gpu` on systems with a GPU):
+
+   ```bash
+   python tune_catboost_optuna_cpu.py --trials 300 --output optuna_best_params.json
+   ```
+
+   The script writes the best model parameters and a suggested threshold to
+   `optuna_best_params.json`.
+
+3. Determine the final decision threshold with out-of-fold predictions:
+
+   ```bash
+   python threshold_scan_final.py --calibrate \
+       --params optuna_best_params.json \
+       --save threshold_results.csv \
+       --save-json best_threshold.json
+   ```
+
+   This saves the threshold sweep to `threshold_results.csv` and the best value
+   to `best_threshold.json`.
+
+4. Train and evaluate the final calibrated model:
+
+   ```bash
+   python model_catboost_final.py
+   ```
+
+The script automatically loads the parameters and threshold from the JSON files
+if they are present.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ decision threshold. A typical workflow is:
 
    The script writes the best model parameters and a suggested threshold to
    `optuna_best_params.json`.
+   Older files using keys like `lr` or `l2` are automatically converted.
 
 3. Determine the final decision threshold with out-of-fold predictions:
 

--- a/model_catboost_final.py
+++ b/model_catboost_final.py
@@ -30,10 +30,20 @@ MODEL_PARAMS = dict(
 PARAMS_FILE = Path(__file__).with_name("optuna_best_params.json")
 THRESHOLD_FILE = Path(__file__).with_name("best_threshold.json")
 
+def _normalize_params(params: dict) -> dict:
+    """Convert shorthand keys from older tuning outputs."""
+    mapping = {
+        "lr": "learning_rate",
+        "l2": "l2_leaf_reg",
+        "bag_temp": "bagging_temperature",
+    }
+    return {mapping.get(k, k): v for k, v in params.items()}
+
 if PARAMS_FILE.exists():
     with open(PARAMS_FILE, encoding="utf-8") as f:
         loaded = json.load(f)
-    MODEL_PARAMS.update(loaded.get("model_params", loaded))
+    params = _normalize_params(loaded.get("model_params", loaded))
+    MODEL_PARAMS.update(params)
     if "threshold" in loaded:
         THRESHOLD = loaded["threshold"]
 

--- a/model_catboost_final.py
+++ b/model_catboost_final.py
@@ -1,3 +1,4 @@
+import json
 import numpy as np
 import pandas as pd
 from pathlib import Path
@@ -25,6 +26,20 @@ MODEL_PARAMS = dict(
     random_seed=42,
     verbose=False,
 )
+
+PARAMS_FILE = Path(__file__).with_name("optuna_best_params.json")
+THRESHOLD_FILE = Path(__file__).with_name("best_threshold.json")
+
+if PARAMS_FILE.exists():
+    with open(PARAMS_FILE, encoding="utf-8") as f:
+        loaded = json.load(f)
+    MODEL_PARAMS.update(loaded.get("model_params", loaded))
+    if "threshold" in loaded:
+        THRESHOLD = loaded["threshold"]
+
+if THRESHOLD_FILE.exists():
+    with open(THRESHOLD_FILE, encoding="utf-8") as f:
+        THRESHOLD = json.load(f).get("threshold", THRESHOLD)
 
 # -------------------- Load data --------------------
 csv_path = Path(__file__).with_name("f1_data_2022_to_present.csv")
@@ -75,3 +90,4 @@ auc = roc_auc_score(y, y_probs_calibrated)
 
 print("\n=== Final Calibrated CatBoost Results (Recall-Focused) ===")
 print(f"acc={acc:.3f}  prec={prec:.3f}  rec={rec:.3f}  f1={f1:.3f}  auc={auc:.3f}")
+

--- a/threshold_scan_final.py
+++ b/threshold_scan_final.py
@@ -11,6 +11,16 @@ from sklearn.calibration import CalibratedClassifierCV
 from sklearn.linear_model import LogisticRegression
 from model_catboost_final import MODEL_PARAMS
 
+
+def _normalize_params(params: dict) -> dict:
+    """Convert shorthand keys from older tuning outputs."""
+    mapping = {
+        "lr": "learning_rate",
+        "l2": "l2_leaf_reg",
+        "bag_temp": "bagging_temperature",
+    }
+    return {mapping.get(k, k): v for k, v in params.items()}
+
 # ---------- CLI args ----------
 parser = argparse.ArgumentParser(description="Threshold scan for CatBoost model")
 parser.add_argument("--start", type=float, default=0.50, help="starting threshold (inclusive)")
@@ -26,7 +36,8 @@ args = parser.parse_args()
 if args.params:
     with open(args.params, encoding='utf-8') as f:
         loaded = json.load(f)
-    MODEL_PARAMS.update(loaded.get('model_params', loaded))
+    params = _normalize_params(loaded.get('model_params', loaded))
+    MODEL_PARAMS.update(params)
 
 # ---------- load data ----------
 df = pd.read_csv(Path(args.data))

--- a/threshold_scan_final.py
+++ b/threshold_scan_final.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -17,11 +18,18 @@ parser.add_argument("--end", type=float, default=0.65, help="ending threshold (i
 parser.add_argument("--step", type=float, default=0.02, help="threshold step size")
 parser.add_argument("--calibrate", action="store_true", help="apply Platt calibration")
 parser.add_argument("--save", type=str, default=None, help="optional path to save results as CSV")
+parser.add_argument("--data", type=str, default='f1_data_2022_to_present.csv')
+parser.add_argument("--params", type=str, default=None, help="JSON with model parameters")
+parser.add_argument("--save-json", type=str, default=None, help="optional path to save best threshold as JSON")
 args = parser.parse_args()
 
+if args.params:
+    with open(args.params, encoding='utf-8') as f:
+        loaded = json.load(f)
+    MODEL_PARAMS.update(loaded.get('model_params', loaded))
+
 # ---------- load data ----------
-csv_path = Path(__file__).with_name("f1_data_2022_to_present.csv")
-df = pd.read_csv(csv_path)
+df = pd.read_csv(Path(args.data))
 
 if 'top3_flag' not in df.columns:
     df['top3_flag'] = (df['finishing_position'] <= 3).astype(int)
@@ -68,6 +76,10 @@ print(f"\nBest threshold: {best.threshold:.2f} -> F1 = {best.f1:.3f}, Recall = {
 if args.save:
     df_res.to_csv(args.save, index=False)
     print(f"Saved results to {args.save}")
+if args.save_json:
+    with open(args.save_json, 'w', encoding='utf-8') as f:
+        json.dump({'threshold': float(best.threshold)}, f, indent=2)
+    print(f"Saved best threshold to {args.save_json}")
 
 # ---------- plot ----------
 plt.figure(figsize=(10, 6))
@@ -81,3 +93,4 @@ plt.legend()
 plt.grid(True)
 plt.tight_layout()
 plt.show()
+

--- a/tune_catboost_optuna_cpu.py
+++ b/tune_catboost_optuna_cpu.py
@@ -5,7 +5,11 @@ Run:
     python tune_catboost_optuna_cpu.py --trials 200 --threshold 0.50
 """
 
-import argparse, optuna, numpy as np, pandas as pd
+import argparse
+import json
+import optuna
+import numpy as np
+import pandas as pd
 from pathlib import Path
 from catboost import CatBoostClassifier, Pool
 from group_time_series_split import GroupTimeSeriesSplit
@@ -15,10 +19,12 @@ from sklearn.metrics import f1_score
 parser = argparse.ArgumentParser()
 parser.add_argument('--trials', type=int, default=100)
 parser.add_argument('--threshold', type=float, default=0.50)
+parser.add_argument('--data', type=str, default='f1_data_2022_to_present.csv')
+parser.add_argument('--output', type=str, default='optuna_best_params.json')
 args = parser.parse_args()
 
 # ---------- Data ----------
-df = pd.read_csv(Path(__file__).with_name('f1_data_2022_to_present.csv'))
+df = pd.read_csv(Path(args.data))
 df['top3_flag'] = (df.finishing_position <= 3).astype(int)
 df['group'] = df.season_year.astype(str) + '-' + df.round_number.astype(str)
 drop_cols = ['finishing_position', 'top3_flag', 'group']
@@ -60,3 +66,11 @@ study.optimize(objective, n_trials=args.trials, show_progress_bar=True)
 print('Best F1:', study.best_value)
 print('Best parameters:')
 print(study.best_params)
+
+best = study.best_params.copy()
+threshold = best.pop('thr')
+output = {'model_params': best, 'threshold': threshold}
+with open(args.output, 'w', encoding='utf-8') as f:
+    json.dump(output, f, indent=2)
+print(f'Saved best parameters to {args.output}')
+


### PR DESCRIPTION
## Summary
- extend Optuna tuning scripts with CLI args and JSON export
- allow threshold scanning to load parameters and export best threshold
- load parameters/threshold from JSON in final model
- document advanced tuning workflow in README

## Testing
- `python -m py_compile tune_catboost_optuna_cpu.py tune_catboost_optuna_gpu.py threshold_scan_final.py model_catboost_final.py`

------
https://chatgpt.com/codex/tasks/task_b_68581565859483319efa56c47547a453